### PR TITLE
Improve how Bags are read from file

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wiggly-games/data-structures",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "",
     "main": "src/index.js",
     "types": "src/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,19 @@
 {
   "name": "@wiggly-games/data-structures",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiggly-games/data-structures",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
+      "dependencies": {
+        "@wiggly-games/node-readline": "^1.0.1"
+      },
       "devDependencies": {
         "@types/node": "^20.12.12",
-        "@wiggly-games/files": "^1.1.1"
+        "@wiggly-games/files": "^1.1.3"
       }
     },
     "node_modules/@types/node": {
@@ -23,10 +26,17 @@
       }
     },
     "node_modules/@wiggly-games/files": {
-      "version": "1.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.1/48783ab2f46ff6e6d540814ebfca1c123222755f",
-      "integrity": "sha512-sopUxWT6MNjY/mOfm+4lpPEBubrC766yJ8ipkvkrC4e7UEIeabVhoFNwzZ8xG7PLKoY+jDBxgnkJrQCCXA1msg==",
+      "version": "1.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.3/a4fdb1e872b660237a0bedff63c37824f132343c",
+      "integrity": "sha512-VuRJU7jX4E89FIK1ohOrkrzJCjizChyzWJn/EGej2DmcgT0REQvVUXCuGm3cQV7ydSV9KJQsLQBNzwz34n6hQg==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@wiggly-games/node-readline": {
+      "version": "1.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/node-readline/1.0.1/62837275964b51d28a85001eefcecd22e782e80a",
+      "integrity": "sha512-Vd7KWU0/SVwrGYDwEEjx7XU8mIRwqRO6yHBKmz5MLtrbjCj4FB9nDefbdJD1nAmZjORqrixGOhc8SijhRyNzJQ==",
+      "hasInstallScript": true,
       "license": "ISC"
     },
     "node_modules/undici-types": {
@@ -47,10 +57,15 @@
       }
     },
     "@wiggly-games/files": {
-      "version": "1.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.1/48783ab2f46ff6e6d540814ebfca1c123222755f",
-      "integrity": "sha512-sopUxWT6MNjY/mOfm+4lpPEBubrC766yJ8ipkvkrC4e7UEIeabVhoFNwzZ8xG7PLKoY+jDBxgnkJrQCCXA1msg==",
+      "version": "1.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/files/1.1.3/a4fdb1e872b660237a0bedff63c37824f132343c",
+      "integrity": "sha512-VuRJU7jX4E89FIK1ohOrkrzJCjizChyzWJn/EGej2DmcgT0REQvVUXCuGm3cQV7ydSV9KJQsLQBNzwz34n6hQg==",
       "dev": true
+    },
+    "@wiggly-games/node-readline": {
+      "version": "1.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@wiggly-games/node-readline/1.0.1/62837275964b51d28a85001eefcecd22e782e80a",
+      "integrity": "sha512-Vd7KWU0/SVwrGYDwEEjx7XU8mIRwqRO6yHBKmz5MLtrbjCj4FB9nDefbdJD1nAmZjORqrixGOhc8SijhRyNzJQ=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiggly-games/data-structures",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {
@@ -17,6 +17,9 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "@wiggly-games/files": "^1.1.1"
+    "@wiggly-games/files": "^1.1.3"
+  },
+  "dependencies": {
+    "@wiggly-games/node-readline": "^1.0.1"
   }
 }

--- a/src/Bag/IBag.ts
+++ b/src/Bag/IBag.ts
@@ -1,4 +1,5 @@
-import { Writable, Readable } from "stream";
+import { Reader } from "@wiggly-games/node-readline";
+import { Writable } from "stream";
 
 /*
     Probability Map is designed to add elements, and pull them out later based on how common the element is.
@@ -25,7 +26,10 @@ export interface IBag<T> {
     Clear(): void;
     Entries(): IterableIterator<[T, number]>;
 
+    // Check if this bag and another are equivalent
+    Equals(otherBag: IBag<T>): boolean;
+
     // Data persistence
-    Write(separator: string, writeStream: Writable);
-    Read(separator: string, readStream: Readable, parseValue: (key: string)=>T);
+    Write(writeStream: Writable);
+    Read(reader: Reader, parseValue: (key: string)=>T);
 }

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,6 @@
 import { Bag, Queue } from "./src";
 import * as Files from "@wiggly-games/files"
+import { Reader } from "@wiggly-games/node-readline";
 
 function TestQueue(){
     const queue = new Queue<number>();
@@ -19,6 +20,7 @@ function TestQueue(){
 async function TestBag(){
     const bag = new Bag<number>();
     const bag2 = new Bag<number>();
+    const bag3 = new Bag<number>();
 
     for (let i = 0; i < 50; i++) {
         bag.Add(1);
@@ -30,15 +32,21 @@ async function TestBag(){
         bag.Add(3);
     }
     
+    // Write twice, so that we can push it into two separate bags.
     await Files.WithWriteStream("./Test.txt", (stream) => {
-        return bag.Write("=", stream);
+        return bag.Write(stream);
+    })
+    await Files.WithAppendStream("./Test.txt", (stream) => {
+        return bag.Write(stream);
     })
 
-    await Files.WithReadStream("./Test.txt", (stream) => {
-        return bag2.Read("=", stream, (data) => parseInt(data));
-    });
+    const fileReader = new Reader("./Test.txt");
+    bag2.Read(fileReader, (data) => parseInt(data));
+    bag3.Read(fileReader, (data) => parseInt(data));
 
-    console.log(bag2);
+    console.assert(bag.Equals(bag2), `ERROR: Bag and Bag2 are different.`);
+    console.assert(bag.Equals(bag3), `ERROR: Bag and Bag3 are different.`);
+    console.assert(bag2.Equals(bag3), `ERROR: Bag2 and Bag3 are different.`);
 }
 
 


### PR DESCRIPTION
Improves the process for reading bags from files.

Now allows you to pass in a Reader from [@Wiggly-Games/Node-Readline](https://github.com/Wiggly-Games/Node-ReadLine), so that the current position in file is stored across successive reads. This allows us to store multiple bags within the same file, along with other data if needed, and easily retrieve them all out of that file.

Also added a method for checking if two Bags are equivalent, useful for testing.
Finally, updated dependencies for the WriteStream, which fixes a bug where writes may not have finished before the process would continue.